### PR TITLE
Codechange: Move AI settings back to ai_gui

### DIFF
--- a/src/ai/ai_core.cpp
+++ b/src/ai/ai_core.cpp
@@ -114,7 +114,7 @@
 	cur_company.Restore();
 
 	InvalidateWindowData(WC_SCRIPT_DEBUG, 0, -1);
-	CloseWindowById(WC_SCRIPT_SETTINGS, company);
+	CloseWindowById(WC_AI_SETTINGS, company);
 }
 
 /* static */ void AI::Pause(CompanyID company)
@@ -340,7 +340,7 @@
 
 	InvalidateWindowData(WC_SCRIPT_LIST, 0, 1);
 	SetWindowClassesDirty(WC_SCRIPT_DEBUG);
-	InvalidateWindowClassesData(WC_SCRIPT_SETTINGS);
+	InvalidateWindowClassesData(WC_AI_SETTINGS);
 }
 
 /**

--- a/src/ai/ai_gui.cpp
+++ b/src/ai/ai_gui.cpp
@@ -9,11 +9,14 @@
 
 #include "../stdafx.h"
 #include "../error.h"
+#include "../settings_gui.h"
+#include "../querystring_gui.h"
 #include "../company_base.h"
 #include "../window_func.h"
 #include "../network/network.h"
 #include "../settings_func.h"
 #include "../network/network_content.h"
+#include "../widgets/dropdown_func.h"
 #include "../core/geometry_func.hpp"
 
 #include "ai.hpp"
@@ -68,7 +71,7 @@ static const NWidgetPart _nested_ai_config_widgets[] = {
 
 /** Window definition for the configure AI window. */
 static WindowDesc _ai_config_desc(
-	WDP_CENTER, "settings_script_config", 0, 0,
+	WDP_CENTER, "settings_ai_config", 0, 0,
 	WC_GAME_OPTIONS, WC_NONE,
 	0,
 	_nested_ai_config_widgets, lengthof(_nested_ai_config_widgets)
@@ -96,7 +99,7 @@ struct AIConfigWindow : public Window {
 	void Close() override
 	{
 		CloseWindowByClass(WC_SCRIPT_LIST);
-		CloseWindowByClass(WC_SCRIPT_SETTINGS);
+		CloseWindowByClass(WC_AI_SETTINGS);
 		this->Window::Close();
 	}
 
@@ -221,7 +224,7 @@ struct AIConfigWindow : public Window {
 				break;
 
 			case WID_AIC_CONFIGURE: // change the settings for an AI
-				ShowScriptSettingsWindow((CompanyID)this->selected_slot);
+				ShowAISettingsWindow((CompanyID)this->selected_slot);
 				break;
 
 			case WID_AIC_CLOSE:
@@ -271,3 +274,346 @@ void ShowAIConfigWindow()
 	new AIConfigWindow();
 }
 
+
+/**
+ * Window for settings the parameters of an AI.
+ */
+struct AISettingsWindow : public Window {
+	CompanyID slot;                       ///< The currently show company's setting.
+	ScriptConfig *ai_config;              ///< The configuration we're modifying.
+	int clicked_button;                   ///< The button we clicked.
+	bool clicked_increase;                ///< Whether we clicked the increase or decrease button.
+	bool clicked_dropdown;                ///< Whether the dropdown is open.
+	bool closing_dropdown;                ///< True, if the dropdown list is currently closing.
+	GUITimer timeout;                     ///< Timeout for unclicking the button.
+	int clicked_row;                      ///< The clicked row of settings.
+	int line_height;                      ///< Height of a row in the matrix widget.
+	Scrollbar *vscroll;                   ///< Cache of the vertical scrollbar.
+	typedef std::vector<const ScriptConfigItem *> VisibleSettingsList; ///< typdef for a vector of script settings
+	VisibleSettingsList visible_settings; ///< List of visible AI settings
+
+	/**
+	 * Constructor for the window.
+	 * @param desc The description of the window.
+	 * @param slot The company we're changing the settings for.
+	 */
+	AISettingsWindow(WindowDesc *desc, CompanyID slot) : Window(desc),
+		slot(slot),
+		clicked_button(-1),
+		clicked_dropdown(false),
+		closing_dropdown(false),
+		timeout(0)
+	{
+		assert(slot != OWNER_DEITY);
+		this->ai_config = AIConfig::GetConfig(slot);
+
+		this->CreateNestedTree();
+		this->vscroll = this->GetScrollbar(WID_AIS_SCROLLBAR);
+		this->FinishInitNested(slot);  // Initializes 'this->line_height' as side effect.
+
+		this->RebuildVisibleSettings();
+	}
+
+	/**
+	 * Rebuilds the list of visible settings. AI settings with the flag
+	 * AICONFIG_AI_DEVELOPER set will only be visible if the game setting
+	 * gui.ai_developer_tools is enabled.
+	 */
+	void RebuildVisibleSettings()
+	{
+		visible_settings.clear();
+
+		for (const auto &item : *this->ai_config->GetConfigList()) {
+			bool no_hide = (item.flags & SCRIPTCONFIG_DEVELOPER) == 0;
+			if (no_hide || _settings_client.gui.ai_developer_tools) {
+				visible_settings.push_back(&item);
+			}
+		}
+
+		this->vscroll->SetCount((int)this->visible_settings.size());
+	}
+
+	void UpdateWidgetSize(int widget, Dimension *size, const Dimension &padding, Dimension *fill, Dimension *resize) override
+	{
+		if (widget != WID_AIS_BACKGROUND) return;
+
+		this->line_height = std::max(SETTING_BUTTON_HEIGHT, FONT_HEIGHT_NORMAL) + padding.height;
+
+		resize->width = 1;
+		resize->height = this->line_height;
+		size->height = 5 * this->line_height;
+	}
+
+	void DrawWidget(const Rect &r, int widget) const override
+	{
+		if (widget != WID_AIS_BACKGROUND) return;
+
+		ScriptConfig *config = this->ai_config;
+		VisibleSettingsList::const_iterator it = this->visible_settings.begin();
+		int i = 0;
+		for (; !this->vscroll->IsVisible(i); i++) it++;
+
+		Rect ir = r.Shrink(WidgetDimensions::scaled.framerect);
+		bool rtl = _current_text_dir == TD_RTL;
+		Rect br = ir.WithWidth(SETTING_BUTTON_WIDTH, rtl);
+		Rect tr = ir.Indent(SETTING_BUTTON_WIDTH + WidgetDimensions::scaled.hsep_wide, rtl);
+
+		int y = r.top;
+		int button_y_offset = (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
+		int text_y_offset = (this->line_height - FONT_HEIGHT_NORMAL) / 2;
+		for (; this->vscroll->IsVisible(i) && it != visible_settings.end(); i++, it++) {
+			const ScriptConfigItem &config_item = **it;
+			int current_value = config->GetSetting((config_item).name);
+			bool editable = this->IsEditableItem(config_item);
+
+			StringID str;
+			TextColour colour;
+			uint idx = 0;
+			if (StrEmpty(config_item.description)) {
+				if (!strcmp(config_item.name, "start_date")) {
+					/* Build-in translation */
+					str = STR_AI_SETTINGS_START_DELAY;
+					colour = TC_LIGHT_BLUE;
+				} else {
+					str = STR_JUST_STRING;
+					colour = TC_ORANGE;
+				}
+			} else {
+				str = STR_AI_SETTINGS_SETTING;
+				colour = TC_LIGHT_BLUE;
+				SetDParamStr(idx++, config_item.description);
+			}
+
+			if ((config_item.flags & SCRIPTCONFIG_BOOLEAN) != 0) {
+				DrawBoolButton(br.left, y + button_y_offset, current_value != 0, editable);
+				SetDParam(idx++, current_value == 0 ? STR_CONFIG_SETTING_OFF : STR_CONFIG_SETTING_ON);
+			} else {
+				if (config_item.complete_labels) {
+					DrawDropDownButton(br.left, y + button_y_offset, COLOUR_YELLOW, this->clicked_row == i && clicked_dropdown, editable);
+				} else {
+					DrawArrowButtons(br.left, y + button_y_offset, COLOUR_YELLOW, (this->clicked_button == i) ? 1 + (this->clicked_increase != rtl) : 0, editable && current_value > config_item.min_value, editable && current_value < config_item.max_value);
+				}
+				if (config_item.labels != nullptr && config_item.labels->Contains(current_value)) {
+					SetDParam(idx++, STR_JUST_RAW_STRING);
+					SetDParamStr(idx++, config_item.labels->Find(current_value)->second);
+				} else {
+					SetDParam(idx++, STR_JUST_INT);
+					SetDParam(idx++, current_value);
+				}
+			}
+
+			DrawString(tr.left, tr.right, y + text_y_offset, str, colour);
+			y += this->line_height;
+		}
+	}
+
+	void OnPaint() override
+	{
+		if (this->closing_dropdown) {
+			this->closing_dropdown = false;
+			this->clicked_dropdown = false;
+		}
+		this->DrawWidgets();
+	}
+
+	void OnClick(Point pt, int widget, int click_count) override
+	{
+		switch (widget) {
+			case WID_AIS_BACKGROUND: {
+				Rect r = this->GetWidget<NWidgetBase>(widget)->GetCurrentRect().Shrink(WidgetDimensions::scaled.matrix, RectPadding::zero);
+				int num = (pt.y - r.top) / this->line_height + this->vscroll->GetPosition();
+				if (num >= (int)this->visible_settings.size()) break;
+
+				VisibleSettingsList::const_iterator it = this->visible_settings.begin();
+				for (int i = 0; i < num; i++) it++;
+				const ScriptConfigItem config_item = **it;
+				if (!this->IsEditableItem(config_item)) return;
+
+				if (this->clicked_row != num) {
+					this->CloseChildWindows(WC_QUERY_STRING);
+					HideDropDownMenu(this);
+					this->clicked_row = num;
+					this->clicked_dropdown = false;
+				}
+
+				bool bool_item = (config_item.flags & SCRIPTCONFIG_BOOLEAN) != 0;
+
+				int x = pt.x - r.left;
+				if (_current_text_dir == TD_RTL) x = r.Width() - 1 - x;
+
+				/* One of the arrows is clicked (or green/red rect in case of bool value) */
+				int old_val = this->ai_config->GetSetting(config_item.name);
+				if (!bool_item && IsInsideMM(x, 0, SETTING_BUTTON_WIDTH) && config_item.complete_labels) {
+					if (this->clicked_dropdown) {
+						/* unclick the dropdown */
+						HideDropDownMenu(this);
+						this->clicked_dropdown = false;
+						this->closing_dropdown = false;
+					} else {
+						int rel_y = (pt.y - r.top) % this->line_height;
+
+						Rect wi_rect;
+						wi_rect.left = pt.x - (_current_text_dir == TD_RTL ? SETTING_BUTTON_WIDTH - 1 - x : x);
+						wi_rect.right = wi_rect.left + SETTING_BUTTON_WIDTH - 1;
+						wi_rect.top = pt.y - rel_y + (this->line_height - SETTING_BUTTON_HEIGHT) / 2;
+						wi_rect.bottom = wi_rect.top + SETTING_BUTTON_HEIGHT - 1;
+
+						/* If the mouse is still held but dragged outside of the dropdown list, keep the dropdown open */
+						if (pt.y >= wi_rect.top && pt.y <= wi_rect.bottom) {
+							this->clicked_dropdown = true;
+							this->closing_dropdown = false;
+
+							DropDownList list;
+							for (int i = config_item.min_value; i <= config_item.max_value; i++) {
+								list.emplace_back(new DropDownListCharStringItem(config_item.labels->Find(i)->second, i, false));
+							}
+
+							ShowDropDownListAt(this, std::move(list), old_val, -1, wi_rect, COLOUR_ORANGE, true);
+						}
+					}
+				} else if (IsInsideMM(x, 0, SETTING_BUTTON_WIDTH)) {
+					int new_val = old_val;
+					if (bool_item) {
+						new_val = !new_val;
+					} else {
+						/* Increase/Decrease button clicked */
+						this->clicked_increase = (x >= SETTING_BUTTON_WIDTH / 2);
+						new_val = this->clicked_increase ?
+							std::min(config_item.max_value, new_val + config_item.step_size) :
+							std::max(config_item.min_value, new_val - config_item.step_size);
+					}
+
+					if (new_val != old_val) {
+						this->ai_config->SetSetting(config_item.name, new_val);
+						this->clicked_button = num;
+						this->timeout.SetInterval(150);
+					}
+				} else if (!bool_item && !config_item.complete_labels) {
+					/* Display a query box so users can enter a custom value. */
+					SetDParam(0, old_val);
+					ShowQueryString(STR_JUST_INT, STR_CONFIG_SETTING_QUERY_CAPTION, 10, this, CS_NUMERAL, QSF_NONE);
+				}
+				this->SetDirty();
+				break;
+			}
+
+			case WID_AIS_ACCEPT:
+				this->Close();
+				break;
+
+			case WID_AIS_RESET:
+				this->ai_config->ResetEditableSettings(_game_mode == GM_MENU || !Company::IsValidID(this->slot));
+				this->SetDirty();
+				break;
+		}
+	}
+
+	void OnQueryTextFinished(char *str) override
+	{
+		if (StrEmpty(str)) return;
+		int32 value = atoi(str);
+
+		SetValue(value);
+	}
+
+	void OnDropdownSelect(int widget, int index) override
+	{
+		assert(this->clicked_dropdown);
+		SetValue(index);
+	}
+
+	void OnDropdownClose(Point pt, int widget, int index, bool instant_close) override
+	{
+		/* We cannot raise the dropdown button just yet. OnClick needs some hint, whether
+		 * the same dropdown button was clicked again, and then not open the dropdown again.
+		 * So, we only remember that it was closed, and process it on the next OnPaint, which is
+		 * after OnClick. */
+		assert(this->clicked_dropdown);
+		this->closing_dropdown = true;
+		this->SetDirty();
+	}
+
+	void OnResize() override
+	{
+		this->vscroll->SetCapacityFromWidget(this, WID_AIS_BACKGROUND);
+	}
+
+	void OnRealtimeTick(uint delta_ms) override
+	{
+		if (this->timeout.Elapsed(delta_ms)) {
+			this->clicked_button = -1;
+			this->SetDirty();
+		}
+	}
+
+	/**
+	 * Some data on this window has become invalid.
+	 * @param data Information about the changed data.
+	 * @param gui_scope Whether the call is done from GUI scope. You may not do everything when not in GUI scope. See #InvalidateWindowData() for details.
+	 */
+	void OnInvalidateData(int data = 0, bool gui_scope = true) override
+	{
+		this->RebuildVisibleSettings();
+		HideDropDownMenu(this);
+		this->CloseChildWindows(WC_QUERY_STRING);
+	}
+
+private:
+	bool IsEditableItem(const ScriptConfigItem &config_item) const
+	{
+		return _game_mode == GM_MENU
+			|| _game_mode == GM_EDITOR
+			|| !Company::IsValidID(this->slot)
+			|| (config_item.flags & SCRIPTCONFIG_INGAME) != 0
+			|| _settings_client.gui.ai_developer_tools;
+	}
+
+	void SetValue(int value)
+	{
+		VisibleSettingsList::const_iterator it = this->visible_settings.begin();
+		for (int i = 0; i < this->clicked_row; i++) it++;
+		const ScriptConfigItem config_item = **it;
+		if (_game_mode == GM_NORMAL && Company::IsValidID(this->slot) && (config_item.flags & SCRIPTCONFIG_INGAME) == 0) return;
+		this->ai_config->SetSetting(config_item.name, value);
+		this->SetDirty();
+	}
+};
+
+/** Widgets for the Script settings window. */
+static const NWidgetPart _nested_ai_settings_widgets[] = {
+	NWidget(NWID_HORIZONTAL),
+		NWidget(WWT_CLOSEBOX, COLOUR_MAUVE),
+		NWidget(WWT_CAPTION, COLOUR_MAUVE, WID_AIS_CAPTION), SetDataTip(STR_AI_SETTINGS_CAPTION, STR_TOOLTIP_WINDOW_TITLE_DRAG_THIS),
+		NWidget(WWT_DEFSIZEBOX, COLOUR_MAUVE),
+	EndContainer(),
+	NWidget(NWID_HORIZONTAL),
+		NWidget(WWT_MATRIX, COLOUR_MAUVE, WID_AIS_BACKGROUND), SetMinimalSize(188, 182), SetResize(1, 1), SetFill(1, 0), SetMatrixDataTip(1, 0, STR_NULL), SetScrollbar(WID_AIS_SCROLLBAR),
+		NWidget(NWID_VSCROLLBAR, COLOUR_MAUVE, WID_AIS_SCROLLBAR),
+	EndContainer(),
+	NWidget(NWID_HORIZONTAL),
+		NWidget(NWID_HORIZONTAL, NC_EQUALSIZE),
+			NWidget(WWT_PUSHTXTBTN, COLOUR_MAUVE, WID_AIS_ACCEPT), SetResize(1, 0), SetFill(1, 0), SetDataTip(STR_AI_SETTINGS_CLOSE, STR_NULL),
+			NWidget(WWT_PUSHTXTBTN, COLOUR_MAUVE, WID_AIS_RESET), SetResize(1, 0), SetFill(1, 0), SetDataTip(STR_AI_SETTINGS_RESET, STR_NULL),
+		EndContainer(),
+		NWidget(WWT_RESIZEBOX, COLOUR_MAUVE),
+	EndContainer(),
+};
+
+/** Window definition for the AI settings window. */
+static WindowDesc _ai_settings_desc(
+	WDP_CENTER, "settings_ai", 500, 208,
+	WC_AI_SETTINGS, WC_NONE,
+	0,
+	_nested_ai_settings_widgets, lengthof(_nested_ai_settings_widgets)
+);
+
+/**
+ * Open the AI settings window to change the settings for a Script.
+ * @param slot The CompanyID of the Script to change the settings.
+ */
+void ShowAISettingsWindow(CompanyID slot)
+{
+	CloseWindowByClass(WC_SCRIPT_LIST);
+	CloseWindowByClass(WC_AI_SETTINGS);
+	new AISettingsWindow(&_ai_settings_desc, slot);
+}

--- a/src/ai/ai_gui.hpp
+++ b/src/ai/ai_gui.hpp
@@ -10,6 +10,7 @@
 #ifndef AI_GUI_HPP
 #define AI_GUI_HPP
 
+void ShowAISettingsWindow(CompanyID slot);
 void ShowAIConfigWindow();
 
 #endif /* AI_GUI_HPP */

--- a/src/company_cmd.cpp
+++ b/src/company_cmd.cpp
@@ -922,7 +922,7 @@ CommandCost CmdCompanyCtrl(DoCommandFlag flags, CompanyCtrlAction cca, CompanyID
 	}
 
 	InvalidateWindowClassesData(WC_GAME_OPTIONS);
-	InvalidateWindowClassesData(WC_SCRIPT_SETTINGS);
+	InvalidateWindowClassesData(WC_AI_SETTINGS);
 	InvalidateWindowClassesData(WC_SCRIPT_LIST);
 
 	return CommandCost();

--- a/src/game/game_core.cpp
+++ b/src/game/game_core.cpp
@@ -203,7 +203,7 @@
 
 	InvalidateWindowData(WC_SCRIPT_LIST, 0, 1);
 	SetWindowClassesDirty(WC_SCRIPT_DEBUG);
-	InvalidateWindowClassesData(WC_SCRIPT_SETTINGS);
+	InvalidateWindowData(WC_GAME_OPTIONS, WN_GAME_OPTIONS_GS);
 	InvalidateWindowClassesData(WC_GAME_OPTIONS);
 }
 

--- a/src/game/game_gui.cpp
+++ b/src/game/game_gui.cpp
@@ -161,8 +161,8 @@ struct GSConfigWindow : public Window {
 			case WID_GSC_GSLIST: {
 				StringID text = STR_AI_CONFIG_NONE;
 
-				if (GameConfig::GetConfig()->GetInfo() != nullptr) {
-					SetDParamStr(0, GameConfig::GetConfig()->GetInfo()->GetName());
+				if (this->gs_config->GetInfo() != nullptr) {
+					SetDParamStr(0, this->gs_config->GetInfo()->GetName());
 					text = STR_JUST_RAW_STRING;
 				}
 
@@ -239,7 +239,7 @@ struct GSConfigWindow : public Window {
 	void OnClick(Point pt, int widget, int click_count) override
 	{
 		if (widget >= WID_GSC_TEXTFILE && widget < WID_GSC_TEXTFILE + TFT_END) {
-			if (GameConfig::GetConfig() == nullptr) return;
+			if (this->gs_config == nullptr) return;
 
 			ShowScriptTextfileWindow((TextfileType)(widget - WID_GSC_TEXTFILE), (CompanyID)OWNER_DEITY);
 			return;
@@ -320,16 +320,12 @@ struct GSConfigWindow : public Window {
 					int new_val = old_val;
 					if (bool_item) {
 						new_val = !new_val;
-					} else if (x >= SETTING_BUTTON_WIDTH / 2) {
-						/* Increase button clicked */
-						new_val += config_item.step_size;
-						if (new_val > config_item.max_value) new_val = config_item.max_value;
-						this->clicked_increase = true;
 					} else {
-						/* Decrease button clicked */
-						new_val -= config_item.step_size;
-						if (new_val < config_item.min_value) new_val = config_item.min_value;
-						this->clicked_increase = false;
+						/* Increase/Decrease button clicked */
+						this->clicked_increase = (x >= SETTING_BUTTON_WIDTH / 2);
+						new_val = this->clicked_increase ?
+							std::min(config_item.max_value, new_val + config_item.step_size) :
+							std::max(config_item.min_value, new_val - config_item.step_size);
 					}
 
 					if (new_val != old_val) {
@@ -406,7 +402,7 @@ struct GSConfigWindow : public Window {
 		this->SetWidgetDisabledState(WID_GSC_CHANGE, (_game_mode == GM_NORMAL) || !IsEditable());
 
 		for (TextfileType tft = TFT_BEGIN; tft < TFT_END; tft++) {
-			this->SetWidgetDisabledState(WID_GSC_TEXTFILE + tft, GameConfig::GetConfig()->GetTextfile(tft, (CompanyID)OWNER_DEITY) == nullptr);
+			this->SetWidgetDisabledState(WID_GSC_TEXTFILE + tft, this->gs_config->GetTextfile(tft, (CompanyID)OWNER_DEITY) == nullptr);
 		}
 		this->RebuildVisibleSettings();
 		HideDropDownMenu(this);

--- a/src/lang/english.txt
+++ b/src/lang/english.txt
@@ -4623,10 +4623,8 @@ STR_SCREENSHOT_WORLD_SCREENSHOT                                 :{BLACK}Whole ma
 STR_SCREENSHOT_HEIGHTMAP_SCREENSHOT                             :{BLACK}Heightmap screenshot
 STR_SCREENSHOT_MINIMAP_SCREENSHOT                               :{BLACK}Minimap screenshot
 
-# Script Parameters
-STR_AI_SETTINGS_CAPTION                                         :{WHITE}{STRING} Parameters
-STR_AI_SETTINGS_CAPTION_AI                                      :AI
-STR_AI_SETTINGS_CAPTION_GAMESCRIPT                              :Game Script
+# AI Parameters
+STR_AI_SETTINGS_CAPTION                                         :{WHITE}AI Parameters
 STR_AI_SETTINGS_CLOSE                                           :{BLACK}Close
 STR_AI_SETTINGS_RESET                                           :{BLACK}Reset
 STR_AI_SETTINGS_SETTING                                         :{RAW_STRING}: {ORANGE}{STRING1}

--- a/src/script/script_gui.h
+++ b/src/script/script_gui.h
@@ -15,7 +15,6 @@
 
 void ShowScriptListWindow(CompanyID slot);
 Window *ShowScriptDebugWindow(CompanyID show_company = INVALID_COMPANY);
-void ShowScriptSettingsWindow(CompanyID slot);
 void ShowScriptTextfileWindow(TextfileType file_type, CompanyID slot);
 void ShowScriptDebugWindowIfScriptError();
 void InitializeScriptGui();

--- a/src/table/settings/gui_settings.ini
+++ b/src/table/settings/gui_settings.ini
@@ -779,7 +779,7 @@ cat      = SC_EXPERT
 var      = gui.ai_developer_tools
 flags    = SF_NOT_IN_SAVE | SF_NO_NETWORK_SYNC
 def      = false
-post_cb  = [](auto) { InvalidateWindowClassesData(WC_SCRIPT_SETTINGS); }
+post_cb  = [](auto) { InvalidateWindowClassesData(WC_AI_SETTINGS); InvalidateWindowData(WC_GAME_OPTIONS, WN_GAME_OPTIONS_GS); InvalidateWindowClassesData(WC_SCRIPT_DEBUG); }
 cat      = SC_EXPERT
 
 [SDTC_BOOL]

--- a/src/widgets/ai_widget.h
+++ b/src/widgets/ai_widget.h
@@ -29,4 +29,13 @@ enum AIConfigWidgets {
 	WID_AIC_CONTENT_DOWNLOAD = WID_AIC_TEXTFILE + TFT_END, ///< Download content button.
 };
 
+/** Widgets of the #AISettingsWindow class. */
+enum AISettingsWidgets {
+	WID_AIS_CAPTION,    ///< Caption of the window.
+	WID_AIS_BACKGROUND, ///< Panel to draw the settings on.
+	WID_AIS_SCROLLBAR,  ///< Scrollbar to scroll through all settings.
+	WID_AIS_ACCEPT,     ///< Accept button.
+	WID_AIS_RESET,      ///< Reset button.
+};
+
 #endif /* WIDGETS_AI_WIDGET_H */

--- a/src/widgets/script_widget.h
+++ b/src/widgets/script_widget.h
@@ -22,15 +22,6 @@ enum ScriptListWidgets {
 	WID_SCRL_CANCEL,    ///< Cancel button.
 };
 
-/** Widgets of the #ScriptSettingsWindow class. */
-enum ScriptSettingsWidgets {
-	WID_SCRS_CAPTION,    ///< Caption of the window.
-	WID_SCRS_BACKGROUND, ///< Panel to draw the settings on.
-	WID_SCRS_SCROLLBAR,  ///< Scrollbar to scroll through all settings.
-	WID_SCRS_ACCEPT,     ///< Accept button.
-	WID_SCRS_RESET,      ///< Reset button.
-};
-
 /** Widgets of the #ScriptDebugWindow class. */
 enum ScriptDebugWidgets {
 	WID_SCRD_VIEW,                 ///< The row of company buttons.

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -1368,7 +1368,7 @@ static uint GetWindowZPriority(WindowClass wc)
 		case WC_NETWORK_WINDOW:
 		case WC_GRF_PARAMETERS:
 		case WC_SCRIPT_LIST:
-		case WC_SCRIPT_SETTINGS:
+		case WC_AI_SETTINGS:
 		case WC_TEXTFILE:
 			++z_priority;
 			FALLTHROUGH;

--- a/src/window_type.h
+++ b/src/window_type.h
@@ -162,10 +162,10 @@ enum WindowClass {
 
 
 	/**
-	 * Script settings; %Window numbers:
-	 *   - 0 = #ScriptSettingsWidgets
+	 * AI settings; %Window numbers:
+	 *   - 0 = #AISettingsWidgets
 	 */
-	WC_SCRIPT_SETTINGS,
+	WC_AI_SETTINGS,
 
 	/**
 	 * NewGRF parameters; %Window numbers:


### PR DESCRIPTION
This also opens GS's own config window from Debug window, and reverts caption fixes.

## Motivation / Problem

<!--
Describe here shortly
* For bug fixes:
    * What problem does this solve?
    * If there is already an issue, link the issue, otherwise describe the problem here.
* For features or gameplay changes:
    * What was the motivation to develop this feature?
    * Does this address any problem with the gameplay or interface?
    * Which group of players do you think would enjoy this feature?
-->


## Description

<!--
Describe here shortly
* For bug fixes:
    * How is the problem solved?
* For features or gameplay changes:
    * What does this feature do?
    * How does it improve/solve the situation described under 'motivation'.
-->


## Limitations

<!--
Describe here
* Is the problem solved in all scenarios?
* Is this feature complete? Are there things that could be added in the future?
* Are there things that are intentionally left out?
* Do you know of a bug or corner case that does not work?
-->


## Checklist for review

Some things are not automated, and forgotten often. This list is a reminder for the reviewers.
* The bug fix is important enough to be backported? (label: 'backport requested')
* This PR touches english.txt or translations? Check the [guidelines](https://github.com/OpenTTD/OpenTTD/blob/master/docs/eints.md)
* This PR affects the save game format? (label 'savegame upgrade')
* This PR affects the GS/AI API? (label 'needs review: Script API')
    * ai_changelog.hpp, gs_changelog.hpp need updating.
    * The compatibility wrappers (compat_*.nut) need updating.
* This PR affects the NewGRF API? (label 'needs review: NewGRF')
    * newgrf_debug_data.h may need updating.
    * [PR must be added to API tracker](https://wiki.openttd.org/en/Development/NewGRF/Specification%20Status)
